### PR TITLE
Huge refactoring of SpotifyService

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,3 +117,5 @@ gem "sidekiq", "~> 7.2", ">= 7.2.2"
 gem "acts-as-taggable-on", "~> 10.0"
 # Icons
 gem "heroicon", "~> 1.0"
+# A library for bulk inserting data using ActiveRecord.
+gem "activerecord-import", "~> 1.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     activerecord (7.0.8)
       activemodel (= 7.0.8)
       activesupport (= 7.0.8)
+    activerecord-import (1.6.0)
+      activerecord (>= 4.2)
     activestorage (7.0.8)
       actionpack (= 7.0.8)
       activejob (= 7.0.8)
@@ -401,6 +403,7 @@ PLATFORMS
   arm64-darwin-23
 
 DEPENDENCIES
+  activerecord-import (~> 1.6)
   acts-as-taggable-on (~> 10.0)
   annotate
   bootsnap

--- a/app/controllers/spotify/followed_artists_controller.rb
+++ b/app/controllers/spotify/followed_artists_controller.rb
@@ -28,7 +28,7 @@ module Spotify
 
     # Only allow to fetch the followed artists from Spotify
     def create
-      SpotifyService.new(current_user).fetch_and_load_artists
+      FollowedArtistsService.new(current_user).fetch_and_load_artists
 
       head :ok
     end

--- a/app/services/followed_artists_service.rb
+++ b/app/services/followed_artists_service.rb
@@ -58,17 +58,24 @@ class FollowedArtistsService
   # This method takes an array of artists and inserts them into the database. It creates new records in the artists table
   # with the provided information for each artist. If the provided array is empty, no database operation is performed.
   #
-  # @param artists [Array<Hash>] An array containing hashes with information about the artists to be created.
+  # @param artists_to_create [Array<Hash>] An array containing hashes with information about the artists to be created.
   #   Each hash should contain the following keys:
   #   - :name (String): The name of the artist.
   #   - :external_link (String): The external link to the artist, typically a URI.
   #   - :cover_url (String): The URL of the artist's cover image.
   # @return [void]
-  # TODO: Use gem active import to manage insert_all
-  def create_artists(artists)
-    return if artists.empty?
+  def create_artists(artists_to_create)
+    return if artists_to_create.empty?
 
-    Artist.insert_all(artists.map { |a| { name: a.name, external_link: a.uri, cover_url: a.images.last&.dig("url") }  }, unique_by: :name)
+    artists = artists_to_create.map do |a|
+      Artist.new(
+        name: a.name,
+        external_link: a.uri,
+        cover_url: a.images.last&.dig("url")
+      )
+    end
+
+    Artist.import(artists)
   end
 
   # Filter out new followed artists from the fetched list that are not already linked to the user.

--- a/app/services/followed_artists_service.rb
+++ b/app/services/followed_artists_service.rb
@@ -12,7 +12,7 @@ class FollowedArtistsService
   # @return [void]
   def fetch_and_load_artists
     ActiveRecord::Base.transaction do
-      fetched_artists = SpotifyService.new(@current_user.spotify_user).fetch_all_followed_artists
+      fetched_artists = SpotifyService.new(@current_user.spotify_user).artists
       create_new_artists(fetched_artists)
       follow_new_artists(fetched_artists)
       remove_unfollowed_artists(fetched_artists)
@@ -41,39 +41,19 @@ class FollowedArtistsService
 
   # Filter out artists from the fetched list that are not already present in the database.
   #
-  # This method takes an array of fetched artists and compares their names with
-  # the names of artists already existing in the database. It returns a new array
-  # containing only the artists from the fetched list that are not present in the database.
-  #
   # @param fetched_artists [Array<Artist>] An array of artists fetched from an external source.
   # @return [Array<Artist>] An array of artists to be created in the database.
-  # TODO: Try to improve this method by searching existing artists by their Spotify_id rather than their names
   def new_artists_to_create(fetched_artists)
     existing_artist_names = Artist.where(name: fetched_artists.map(&:name)).pluck(:name)
-    fetched_artists.reject { |followed_artist| existing_artist_names.include?(followed_artist.name) }
+    fetched_artists.reject { |fa| existing_artist_names.include?(fa.name) }
   end
 
   # Insert artists into the database.
   #
-  # This method takes an array of artists and inserts them into the database. It creates new records in the artists table
-  # with the provided information for each artist. If the provided array is empty, no database operation is performed.
-  #
-  # @param artists_to_create [Array<Hash>] An array containing hashes with information about the artists to be created.
-  #   Each hash should contain the following keys:
-  #   - :name (String): The name of the artist.
-  #   - :external_link (String): The external link to the artist, typically a URI.
-  #   - :cover_url (String): The URL of the artist's cover image.
+  # @param artists [Array<Artist>] An array containing Artist objects.
   # @return [void]
-  def create_artists(artists_to_create)
-    return if artists_to_create.empty?
-
-    artists = artists_to_create.map do |a|
-      Artist.new(
-        name: a.name,
-        external_link: a.uri,
-        cover_url: a.images.last&.dig("url")
-      )
-    end
+  def create_artists(artists)
+    return if artists.empty?
 
     Artist.import(artists)
   end
@@ -86,10 +66,9 @@ class FollowedArtistsService
   #
   # @param fetched_artists [Array<Artist>] An array of artists fetched from an external source.
   # @return [Array<Artist>] An array of new artists to be followed by the user.
-  # TODO: Try to improve this method by searching existing artists by their Spotify_id rather than their names
   def artists_to_follow(fetched_artists)
     existing_followed_artists_names = @current_user.artists.where(name: fetched_artists.map(&:name)).pluck(:name)
-    fetched_artists.reject { |followed_artist| existing_followed_artists_names.include?(followed_artist.name) }
+    fetched_artists.reject { |fa| existing_followed_artists_names.include?(fa.name) }
   end
 
 

--- a/app/services/followed_artists_service.rb
+++ b/app/services/followed_artists_service.rb
@@ -1,0 +1,105 @@
+require 'json'
+
+class FollowedArtistsService
+  attr_reader :current_user
+
+  def initialize(current_user)
+    @current_user = current_user
+    @spotify_user = current_user.spotify_user
+  end
+
+
+  # TODO: [⚡️Performance Tip] I should :
+  #         # - add an attribute spotify_id to Artist
+  #         # - create a table index on spotify_id
+  #         # - do the find_or_create_by on artist.spotify_id
+  #         # Peformance will be better by searching on an Integer than on a String
+  # Fetches artists from Spotify and loads them into the database, associating them with the current user.
+  #
+  # @return [void]
+  def fetch_and_load_artists
+    ActiveRecord::Base.transaction do
+      fetched_artists = fetch_artists
+      create_new_artists(fetched_artists)
+      follow_new_artists(fetched_artists)
+      remove_unfollowed_artists(fetched_artists)
+    end
+  end
+
+  private
+
+
+  # Create new artists in the database.
+  #
+  # This method takes an array of fetched artists and filters out the ones that are not already existing
+  # in the database. It then inserts the new artists into the database.
+  #
+  # @param fetched_artists [Array<Artist>] An array of artists fetched from an external source.
+  # @return [void]
+  def create_new_artists(fetched_artists)
+    new_artists = new_artists_to_create(fetched_artists)
+    create_artists_in_db(new_artists)
+  end
+
+  # TODO: There may be an extra step here that could be optimized...
+  def follow_new_artists(fetched_artists)
+    # Get the uniq artists not already followed by the user
+    new_artists_to_follow = artists_to_follow(fetched_artists)
+
+    # Fetch artist IDs for newly created and existing artists
+    artist_ids_to_follow = Artist.where(name: new_artists_to_follow.map(&:name)).pluck(:id)
+
+    # Attach new artists to the current user
+    @current_user.followed_artists.create!(artist_ids_to_follow.map { |artist_id| { artist_id: artist_id } })
+  end
+
+  # Filter out artists from the fetched list that are not already present in the database.
+  #
+  # This method takes an array of fetched artists and compares their names with
+  # the names of artists already existing in the database. It returns a new array
+  # containing only the artists from the fetched list that are not present in the database.
+  #
+  # @param fetched_artists [Array<Artist>] An array of artists fetched from an external source.
+  # @return [Array<Artist>] An array of artists to be created in the database.
+  # TODO: Try to improve this method by searching existing artists by their Spotify_id rather than their names
+  def new_artists_to_create(fetched_artists)
+    existing_artist_names = Artist.where(name: fetched_artists.map(&:name)).pluck(:name)
+    fetched_artists.reject { |followed_artist| existing_artist_names.include?(followed_artist.name) }
+  end
+
+  # Filter out new followed artists from the fetched list that are not already linked to the user.
+  #
+  # This method takes an array of fetched artists and compares their names with
+  # the names of artists already followed by the current user. It returns a new array
+  # containing only the artists from the fetched list that are not already followed by the user.
+  #
+  # @param fetched_artists [Array<Artist>] An array of artists fetched from an external source.
+  # @return [Array<Artist>] An array of new artists to be followed by the user.
+  # TODO: Try to improve this method by searching existing artists by their Spotify_id rather than their names
+  def artists_to_follow(fetched_artists)
+    existing_followed_artists_names = @current_user.artists.where(name: fetched_artists.map(&:name)).pluck(:name)
+    fetched_artists.reject { |followed_artist| existing_followed_artists_names.include?(followed_artist.name) }
+  end
+
+  # TODO: Use gem active import to manage insert_all
+  def create_artists_in_db(spotify_artists_to_create)
+    unless spotify_artists_to_create.empty?
+      Artist.insert_all(spotify_artists_to_create.map { |artist| { name: artist.name, external_link: artist.uri, cover_url: artist.images.last&.dig("url") }  }, unique_by: :name)
+    end
+  end
+
+  # Removes unfollowed artists from the current user's followed artists.
+  #
+  # @param all_followed_artists [Array<Artist>] the list of all followed artists fetched from Spotify
+  # @return [void]
+  def remove_unfollowed_artists(all_followed_artists)
+    prev_followed_artist_names = @current_user.artists.pluck(:name)
+    new_followed_artists_names = all_followed_artists.map(&:name)
+    artists_names_to_unfollow = prev_followed_artist_names - new_followed_artists_names
+
+    return if artists_names_to_unfollow.empty?
+
+    artists_ids_to_delete = @current_user.artists.where(name: artists_names_to_unfollow).pluck(:id)
+    @current_user.followed_artists.where(artist_id: artists_ids_to_delete).destroy_all
+  end
+end

--- a/app/services/followed_artists_service.rb
+++ b/app/services/followed_artists_service.rb
@@ -97,7 +97,6 @@ class FollowedArtistsService
     Artist.where(name: new_artists_to_follow.map(&:name)).pluck(:id)
   end
 
-
   # Attach new followed artists to the current user.
   #
   # This method takes an array of artist IDs to be followed by the user and associates them with the current user

--- a/app/services/followed_artists_service.rb
+++ b/app/services/followed_artists_service.rb
@@ -53,8 +53,6 @@ class FollowedArtistsService
   # @param artists [Array<Artist>] An array containing Artist objects.
   # @return [void]
   def create_artists(artists)
-    return if artists.empty?
-
     Artist.import(artists)
   end
 

--- a/app/services/followed_artists_service.rb
+++ b/app/services/followed_artists_service.rb
@@ -7,11 +7,6 @@ class FollowedArtistsService
     @current_user = current_user
   end
 
-  # TODO: [⚡️Performance Tip] I should :
-  #         # - add an attribute spotify_id to Artist
-  #         # - create a table index on spotify_id
-  #         # - do the find_or_create_by on artist.spotify_id
-  #         # Peformance will be better by searching on an Integer than on a String
   # Fetches artists from Spotify and loads them into the database, associating them with the current user.
   #
   # @return [void]
@@ -38,7 +33,6 @@ class FollowedArtistsService
     create_artists(new_artists)
   end
 
-  # TODO: There may be an extra step here that could be optimized...
   def follow_new_artists(fetched_artists)
     new_artists_to_follow = artists_to_follow(fetched_artists)
     artist_ids_to_follow = fetch_artist_ids_to_follow(new_artists_to_follow)

--- a/app/services/followed_artists_service.rb
+++ b/app/services/followed_artists_service.rb
@@ -5,9 +5,7 @@ class FollowedArtistsService
 
   def initialize(current_user)
     @current_user = current_user
-    @spotify_user = current_user.spotify_user
   end
-
 
   # TODO: [⚡️Performance Tip] I should :
   #         # - add an attribute spotify_id to Artist
@@ -19,7 +17,7 @@ class FollowedArtistsService
   # @return [void]
   def fetch_and_load_artists
     ActiveRecord::Base.transaction do
-      fetched_artists = fetch_artists
+      fetched_artists = SpotifyService.new(@current_user.spotify_user).fetch_all_followed_artists
       create_new_artists(fetched_artists)
       follow_new_artists(fetched_artists)
       remove_unfollowed_artists(fetched_artists)

--- a/app/services/followed_artists_service.rb
+++ b/app/services/followed_artists_service.rb
@@ -35,7 +35,7 @@ class FollowedArtistsService
   # @return [void]
   def create_new_artists(fetched_artists)
     new_artists = new_artists_to_create(fetched_artists)
-    create_artists_in_db(new_artists)
+    create_artists(new_artists)
   end
 
   # TODO: There may be an extra step here that could be optimized...
@@ -59,11 +59,22 @@ class FollowedArtistsService
     fetched_artists.reject { |followed_artist| existing_artist_names.include?(followed_artist.name) }
   end
 
+  # Insert artists into the database.
+  #
+  # This method takes an array of artists and inserts them into the database. It creates new records in the artists table
+  # with the provided information for each artist. If the provided array is empty, no database operation is performed.
+  #
+  # @param artists [Array<Hash>] An array containing hashes with information about the artists to be created.
+  #   Each hash should contain the following keys:
+  #   - :name (String): The name of the artist.
+  #   - :external_link (String): The external link to the artist, typically a URI.
+  #   - :cover_url (String): The URL of the artist's cover image.
+  # @return [void]
   # TODO: Use gem active import to manage insert_all
-  def create_artists_in_db(spotify_artists_to_create)
-    unless spotify_artists_to_create.empty?
-      Artist.insert_all(spotify_artists_to_create.map { |artist| { name: artist.name, external_link: artist.uri, cover_url: artist.images.last&.dig("url") }  }, unique_by: :name)
-    end
+  def create_artists(artists)
+    return if artists.empty?
+
+    Artist.insert_all(artists.map { |a| { name: a.name, external_link: a.uri, cover_url: a.images.last&.dig("url") }  }, unique_by: :name)
   end
 
   # Filter out new followed artists from the fetched list that are not already linked to the user.

--- a/app/services/followed_artists_service.rb
+++ b/app/services/followed_artists_service.rb
@@ -44,9 +44,11 @@ class FollowedArtistsService
     # Get the uniq artists not already followed by the user
     new_artists_to_follow = artists_to_follow(fetched_artists)
 
+    # TODO: extract this code into a method
     # Fetch artist IDs for newly created and existing artists
     artist_ids_to_follow = Artist.where(name: new_artists_to_follow.map(&:name)).pluck(:id)
 
+    # TODO: extract this code into a method
     # Attach new artists to the current user
     @current_user.followed_artists.create!(artist_ids_to_follow.map { |artist_id| { artist_id: artist_id } })
   end

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -4,8 +4,6 @@ class SpotifyService
   SPOTIFY_MAX_LIMIT_PER_PAGE = 50
   MAX_LOOP = 10
 
-  attr_reader :spotify_user
-
   def initialize(spotify_user)
     @spotify_user = spotify_user
   end
@@ -24,6 +22,23 @@ class SpotifyService
   rescue => e
     Rails.logger.error("Unexpected error when fetching total followed artists from Spotify: #{e.message}")
   end
+
+  # This method fetches all followed artists of the current user from Spotify and converts them into an array of Artist objects.
+  #
+  # @return [Array<Artist>] An array containing all fetched artists.
+  def artists
+    fetched_artists = fetch_all_followed_artists
+
+    fetched_artists.map do |a|
+      Artist.new(
+        name: a.name,
+        external_link: a.uri,
+        cover_url: a.images.last&.dig("url")
+      )
+    end
+  end
+
+  private
 
   # Fetches all followed artists of the current user from Spotify.
   #
@@ -49,8 +64,6 @@ class SpotifyService
 
     artists
   end
-
-  private
 
   # Use Spotify's API to fetch a batch of followed artists for current_user
   #

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -1,13 +1,28 @@
-require 'open-uri'
+require 'json'
 
 class SpotifyService
-  MAX_ARTIST_PER_PAGE = 50
+  SPOTIFY_MAX_LIMIT_PER_PAGE = 50
 
   attr_reader :current_user
 
   def initialize(current_user)
     @current_user = current_user
     @spotify_user = current_user.spotify_user
+  end
+
+  # Retrieves the total number of artists followed by the current user from Spotify.
+  #
+  # This method makes a request to the Spotify API to fetch the total number of artists followed by the current user.
+  #
+  # @return [Integer] The total number of artists followed by the current user.
+  def total_followed_artists
+    RSpotify.raw_response = true
+    count = JSON.parse(@current_user.spotify_user.following(type: 'artist'))["artists"]["total"]
+    RSpotify.raw_response = false
+
+    count
+  rescue => e
+    Rails.logger.error("Unexpected error when fetching total followed artists from Spotify: #{e.message}")
   end
 
   # TODO: [⚡️Performance Tip] I should :
@@ -20,65 +35,120 @@ class SpotifyService
   # @return [void]
   def fetch_and_load_artists
     ActiveRecord::Base.transaction do
-      # Fetch all artist names already followed by the user
-      followed_artist_names = @current_user.artists.pluck(:name)
-      all_fetched_artists = []
-      last_artist_id = nil
-      number_of_artists_to_load = MAX_ARTIST_PER_PAGE
+      # Fetch current user's followed artists
+      fetched_artists = fetch_artists
 
-      while number_of_artists_to_load == MAX_ARTIST_PER_PAGE
-        batch_of_fetched_artists = fetch_artists(last_artist_id)
-        all_fetched_artists << batch_of_fetched_artists
-        last_artist_id = batch_of_fetched_artists.last&.id
-        number_of_artists_to_load = batch_of_fetched_artists.size
+      # TODO: Group these two methods in a method called create_new_artists
+      # Get new artists to be created and not already existing in the DB
+      spotify_artists_to_create = artists_to_create_in_db(fetched_artists)
+      # Insert new artists in the DB
+      create_artists_in_db(spotify_artists_to_create)
 
-        # Collect new artists to be created in this batch
-        # TODO: 🐛 Potential bug: We should reject the creation of artists already existing in the table Artists, not only those followed by the current_user
-        spotify_artists_to_create = batch_of_fetched_artists.reject { |followed_artist| followed_artist_names.include?(followed_artist.name) }
+      # TODO: Group these three methods in a method called follow_new_artists
+      # TODO: There may be an extra step here that could be optimized...
+      # Get the uniq artists not already followed by the user
+      new_artists_to_follow = artists_to_follow(fetched_artists)
+      # Fetch artist IDs for newly created and existing artists
+      artist_ids_to_follow = Artist.where(name: new_artists_to_follow.map(&:name)).pluck(:id)
+      # Attach new artists to the current user
+      @current_user.followed_artists.create!(artist_ids_to_follow.map { |artist_id| { artist_id: artist_id } })
 
-        # Insert new artists in a single database query
-        unless spotify_artists_to_create.empty?
-          Artist.insert_all(spotify_artists_to_create.map { |artist| { name: artist.name, external_link: artist.uri, cover_url: artist.images.last&.dig("url") }  }, unique_by: :name)
-        end
-
-        # Fetch artist IDs for newly created and existing artists
-        artist_ids = Artist.where(name: spotify_artists_to_create.map(&:name)).pluck(:id)
-
-        # Attach new artists to the current user
-        @current_user.followed_artists.create!(artist_ids.map { |artist_id| { artist_id: artist_id } })
-      end
-
-      remove_unfollowed_artists(all_fetched_artists, followed_artist_names)
+      # Remove unfollowed artists
+      remove_unfollowed_artists(fetched_artists)
     end
   end
 
   private
 
-  # Use Spotify's API to fetch the following artists
-  def fetch_artists(last_artist_id)
-    @current_user.spotify_user.following(type: 'artist', limit: 50, after: last_artist_id)
+  # Fetches all followed artists of the current user from Spotify.
+  #
+  # This method retrieves all followed artists of the current user from Spotify in batches until either the total number
+  # of fetched artists reaches the total number of followed artists or the maximum loop count is exceeded.
+  #
+  # @return [Array<Artist>] An array containing all fetched artists.
+  def fetch_artists
+    artists = []
+    max_loop = 0
+
+    loop do
+      max_loop += 1
+      batch_of_fetched_artists = fetch_batch_of_artists(artists.last&.id)
+      artists.concat(batch_of_fetched_artists)
+
+      # Break the loop if:
+      # - The batch of fetched artists is empty.
+      # - The total number of fetched artists exceeds or equals the total number of followed artists.
+      # - The maximum loop count exceeds 100.
+      break if batch_of_fetched_artists.empty? || artists.size >= total_followed_artists || max_loop > 100
+    end
+
+    artists
+  end
+
+  # Use Spotify's API to fetch a batch of followed artists for current_user
+  #
+  # @param last_artist_id [String] The ID of the last artist in the previous batch
+  # @return [RSpotify::Artist] An array of artists representing the batch of followed artists, or nil if an error occurs
+  # TODO: Improve this method by returning an array of hash with only the extracted properties we are interested in :
+  #   - name
+  #   - url
+  #   - cover
+  #   - (to come: spotify_id)
+  #   - (to come: genres)
+  def fetch_batch_of_artists(last_artist_id)
+    @current_user.spotify_user.following(type: 'artist', limit: SPOTIFY_MAX_LIMIT_PER_PAGE, after: last_artist_id)
+  rescue RestClient::ExceptionWithResponse => e
+    Rails.logger.error("Error fetching batch of artists from Spotify: #{e.message}")
+    nil
+  end
+
+  # Filter out artists from the fetched list that are not already present in the database.
+  #
+  # This method takes an array of fetched artists and compares their names with
+  # the names of artists already existing in the database. It returns a new array
+  # containing only the artists from the fetched list that are not present in the database.
+  #
+  # @param fetched_artists [Array<Artist>] An array of artists fetched from an external source.
+  # @return [Array<Artist>] An array of artists to be created in the database.
+  # TODO: Try to improve this method by searching existing artists by their Spotify_id rather than their names
+  def artists_to_create_in_db(fetched_artists)
+    existing_artist_names = Artist.where(name: fetched_artists.map(&:name)).pluck(:name)
+    fetched_artists.reject { |followed_artist| existing_artist_names.include?(followed_artist.name) }
+  end
+
+  # Filter out new followed artists from the fetched list that are not already linked to the user.
+  #
+  # This method takes an array of fetched artists and compares their names with
+  # the names of artists already followed by the current user. It returns a new array
+  # containing only the artists from the fetched list that are not already followed by the user.
+  #
+  # @param fetched_artists [Array<Artist>] An array of artists fetched from an external source.
+  # @return [Array<Artist>] An array of new artists to be followed by the user.
+  # TODO: Try to improve this method by searching existing artists by their Spotify_id rather than their names
+  def artists_to_follow(fetched_artists)
+    existing_followed_artists_names = @current_user.artists.where(name: fetched_artists.map(&:name)).pluck(:name)
+    fetched_artists.reject { |followed_artist| existing_followed_artists_names.include?(followed_artist.name) }
+  end
+
+  # TODO: Use gem active import to manage insert_all
+  def create_artists_in_db(spotify_artists_to_create)
+    unless spotify_artists_to_create.empty?
+      Artist.insert_all(spotify_artists_to_create.map { |artist| { name: artist.name, external_link: artist.uri, cover_url: artist.images.last&.dig("url") }  }, unique_by: :name)
+    end
   end
 
   # Removes unfollowed artists from the current user's followed artists.
   #
-  # @param all_followed_artists [Array<Array<Artist>>] the list of all followed artists fetched from Spotify
-  # @param previously_followed_artist_names [Array<String>] the list of names of artists previously followed by the user
+  # @param all_followed_artists [Array<Artist>] the list of all followed artists fetched from Spotify
   # @return [void]
-  def remove_unfollowed_artists(all_followed_artists, previously_followed_artist_names)
-    followed_artists_names = all_followed_artists.flatten.map(&:name)
-    unfollowed_artists_names = previously_followed_artist_names - followed_artists_names
+  def remove_unfollowed_artists(all_followed_artists)
+    prev_followed_artist_names = @current_user.artists.pluck(:name)
+    new_followed_artists_names = all_followed_artists.map(&:name)
+    artists_names_to_unfollow = prev_followed_artist_names - new_followed_artists_names
 
-    return if unfollowed_artists_names.empty?
+    return if artists_names_to_unfollow.empty?
 
-    artists_ids_to_delete = @current_user.artists.where(name: unfollowed_artists_names).pluck(:id)
+    artists_ids_to_delete = @current_user.artists.where(name: artists_names_to_unfollow).pluck(:id)
     @current_user.followed_artists.where(artist_id: artists_ids_to_delete).destroy_all
-  end
-
-  # Converts an artist URI to a Spotify external link.
-  #
-  # @param artist_uri [String] the URI of the artist
-  # @return [String] the Spotify external link for the artist
-  def external_link(artist_uri)
-    "spotify:#{artist_uri}"
   end
 end

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -30,13 +30,13 @@ class SpotifyService
   # of fetched artists reaches the total number of followed artists or the maximum loop count is exceeded.
   #
   # @return [Array<Artist>] An array containing all fetched artists.
-  def fetch_artists
+  def fetch_all_followed_artists
     artists = []
     max_loop = 0
 
     loop do
       max_loop += 1
-      batch_of_fetched_artists = fetch_batch_of_artists(artists.last&.id)
+      batch_of_fetched_artists = fetch_batch_of_followed_artists(artists.last&.id)
       artists.concat(batch_of_fetched_artists)
 
       # Break the loop if:
@@ -61,7 +61,7 @@ class SpotifyService
   #   - cover
   #   - (to come: spotify_id)
   #   - (to come: genres)
-  def fetch_batch_of_artists(last_artist_id)
+  def fetch_batch_of_followed_artists(last_artist_id)
     @spotify_user.following(type: 'artist', limit: SPOTIFY_MAX_LIMIT_PER_PAGE, after: last_artist_id)
   rescue RestClient::ExceptionWithResponse => e
     Rails.logger.error("Error fetching batch of artists from Spotify: #{e.message}")

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -2,6 +2,7 @@ require 'open-uri'
 
 class SpotifyService
   SPOTIFY_MAX_LIMIT_PER_PAGE = 50
+  MAX_LOOP = 10
 
   attr_reader :spotify_user
 
@@ -32,10 +33,10 @@ class SpotifyService
   # @return [Array<Artist>] An array containing all fetched artists.
   def fetch_all_followed_artists
     artists = []
-    max_loop = 0
+    count_loop = 0
 
     loop do
-      max_loop += 1
+      count_loop += 1
       batch_of_fetched_artists = fetch_batch_of_followed_artists(artists.last&.id)
       artists.concat(batch_of_fetched_artists)
 
@@ -43,7 +44,7 @@ class SpotifyService
       # - The batch of fetched artists is empty.
       # - The total number of fetched artists exceeds or equals the total number of followed artists.
       # - The maximum loop count exceeds 100.
-      break if batch_of_fetched_artists.empty? || artists.size >= total_followed_artists || max_loop > 100
+      break if batch_of_fetched_artists.empty? || artists.size >= total_followed_artists || count_loop > MAX_LOOP
     end
 
     artists

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -23,13 +23,12 @@ class SpotifyService
     Rails.logger.error("Unexpected error when fetching total followed artists from Spotify: #{e.message}")
   end
 
-  # This method fetches all followed artists of the current user from Spotify and converts them into an array of Artist objects.
+  # This method fetches all followed artists of the current user from Spotify and converts them into an array of Artist
+  # objects.
   #
   # @return [Array<Artist>] An array containing all fetched artists.
   def artists
-    fetched_artists = fetch_all_followed_artists
-
-    fetched_artists.map do |a|
+    fetch_all_followed_artists.map do |a|
       Artist.new(
         name: a.name,
         external_link: a.uri,

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -45,7 +45,8 @@ class SpotifyService
   #
   # @return [Array<Artist>] An array containing all fetched artists.
   def fetch_all_followed_artists
-    max_loop = (total_followed_artists / SPOTIFY_MAX_LIMIT_PER_PAGE).ceil
+    total_artists = total_followed_artists
+    max_loop = (total_artists / SPOTIFY_MAX_LIMIT_PER_PAGE).ceil
     artists = []
     count_loop = 0
 
@@ -58,7 +59,7 @@ class SpotifyService
       # - The batch of fetched artists is empty.
       # - The total number of fetched artists exceeds or equals the total number of followed artists.
       # - The maximum loop count exceeds max_loop.
-      break if batch_of_fetched_artists.empty? || artists.size >= total_followed_artists || count_loop > max_loop
+      break if batch_of_fetched_artists.empty? || artists.size >= total_artists || count_loop > max_loop
     end
 
     artists

--- a/app/services/spotify_service.rb
+++ b/app/services/spotify_service.rb
@@ -2,7 +2,6 @@ require 'open-uri'
 
 class SpotifyService
   SPOTIFY_MAX_LIMIT_PER_PAGE = 50
-  MAX_LOOP = 10
 
   def initialize(spotify_user)
     @spotify_user = spotify_user
@@ -46,6 +45,7 @@ class SpotifyService
   #
   # @return [Array<Artist>] An array containing all fetched artists.
   def fetch_all_followed_artists
+    max_loop = (total_followed_artists / SPOTIFY_MAX_LIMIT_PER_PAGE).ceil
     artists = []
     count_loop = 0
 
@@ -57,8 +57,8 @@ class SpotifyService
       # Break the loop if:
       # - The batch of fetched artists is empty.
       # - The total number of fetched artists exceeds or equals the total number of followed artists.
-      # - The maximum loop count exceeds 100.
-      break if batch_of_fetched_artists.empty? || artists.size >= total_followed_artists || count_loop > MAX_LOOP
+      # - The maximum loop count exceeds max_loop.
+      break if batch_of_fetched_artists.empty? || artists.size >= total_followed_artists || count_loop > max_loop
     end
 
     artists

--- a/app/sidekiq/fetch_artists_job.rb
+++ b/app/sidekiq/fetch_artists_job.rb
@@ -4,7 +4,7 @@ class FetchArtistsJob
   def perform(user_id)
     user = User.find(user_id)
 
-    SpotifyService.new(user).fetch_and_load_artists
+    FollowedArtistsService.new(user).fetch_and_load_artists
   rescue StandardError => e
     Rails.logger.error "Error fetching followed artists for user #{user_id}: #{e.message}"
   end

--- a/spec/services/followed_artists_service_spec.rb
+++ b/spec/services/followed_artists_service_spec.rb
@@ -73,9 +73,38 @@ RSpec.describe FollowedArtistsService do
       end
     end
 
-    # TODO: Write specs
-    describe "#create_artist_in_db" do
+    describe "#create_artists" do
+      subject(:create_artists) { service.send(:create_artists, artists) }
 
+      context "when artists array is empty" do
+        let(:artists) { [] }
+
+        it "does not perform any database operation" do
+          expect { create_artists }.not_to change(Artist, :count)
+        end
+      end
+
+      context "when artists array is not empty" do
+        let(:artists) do
+          [
+            double("Artist", name: "Artist 1", uri: "spotify:artist1", images: [{ "url" => "http://example.com/artist1.jpg" }]),
+            double("Artist", name: "Artist 2", uri: "spotify:artist2", images: [{ "url" => "http://example.com/artist2.jpg" }])
+          ]
+        end
+
+        it "creates new records in the artists table" do
+          expect { create_artists }.to change(Artist, :count).by(2)
+        end
+
+        it "creates records with correct attributes" do
+          create_artists
+          artist1 = Artist.find_by(name: "Artist 1")
+          artist2 = Artist.find_by(name: "Artist 2")
+
+          expect(artist1).to have_attributes(name: "Artist 1", external_link: "spotify:artist1", cover_url: "http://example.com/artist1.jpg")
+          expect(artist2).to have_attributes(name: "Artist 2", external_link: "spotify:artist2", cover_url: "http://example.com/artist2.jpg")
+        end
+      end
     end
 
     describe "#artists_to_follow" do

--- a/spec/services/followed_artists_service_spec.rb
+++ b/spec/services/followed_artists_service_spec.rb
@@ -14,22 +14,21 @@ RSpec.describe FollowedArtistsService do
 
   describe "public methods" do
     describe "#fetch_and_load_artists" do
-      let(:fetched_artists) { [
-        double("artist", name: "Artist 1", uri: "spotify:artist:1"),
-        double("artist", name: "Artist 2", uri: "spotify:artist:1"),
-      ] }
+      let(:artist1) { double('RSpotify::Artist', name: "Artist 1", uri: "spotify:artist1", images: [{ "url" => "https://artist1.jpg" }]) }
+      let(:artist2) { double('RSpotify::Artist', name: "Artist 2", uri: "spotify:artist2", images: [{ "url" => "https://artist2.jpg" }]) }
+      let(:fetched_artists) { [artist1, artist2] }
 
       subject(:fetch_and_load_artists) { service.fetch_and_load_artists }
 
       before do
-        allow_any_instance_of(SpotifyService).to receive(:fetch_all_followed_artists).and_return(fetched_artists)
+        allow_any_instance_of(SpotifyService).to receive(:artists).and_return(fetched_artists)
         allow_any_instance_of(FollowedArtistsService).to receive(:create_new_artists).with(fetched_artists)
         allow_any_instance_of(FollowedArtistsService).to receive(:follow_new_artists).with(fetched_artists)
         allow_any_instance_of(FollowedArtistsService).to receive(:remove_unfollowed_artists).with(fetched_artists)
       end
 
       it "fetches all followed artists" do
-        expect_any_instance_of(SpotifyService).to receive(:fetch_all_followed_artists)
+        expect_any_instance_of(SpotifyService).to receive(:artists)
         fetch_and_load_artists
       end
 
@@ -85,24 +84,10 @@ RSpec.describe FollowedArtistsService do
       end
 
       context "when artists array is not empty" do
-        let(:artists) do
-          [
-            double("Artist", name: "Artist 1", uri: "spotify:artist1", images: [{ "url" => "http://example.com/artist1.jpg" }]),
-            double("Artist", name: "Artist 2", uri: "spotify:artist2", images: [{ "url" => "http://example.com/artist2.jpg" }])
-          ]
-        end
+        let(:artists) { build_list(:artist, 2) }
 
         it "creates new records in the artists table" do
           expect { create_artists }.to change(Artist, :count).by(2)
-        end
-
-        it "creates records with correct attributes" do
-          create_artists
-          artist1 = Artist.find_by(name: "Artist 1")
-          artist2 = Artist.find_by(name: "Artist 2")
-
-          expect(artist1).to have_attributes(name: "Artist 1", external_link: "spotify:artist1", cover_url: "http://example.com/artist1.jpg")
-          expect(artist2).to have_attributes(name: "Artist 2", external_link: "spotify:artist2", cover_url: "http://example.com/artist2.jpg")
         end
       end
     end

--- a/spec/services/followed_artists_service_spec.rb
+++ b/spec/services/followed_artists_service_spec.rb
@@ -133,9 +133,29 @@ RSpec.describe FollowedArtistsService do
       end
     end
 
-    # TODO: Write specs
     describe "#fetch_artist_ids_to_follow" do
+      subject(:fetch_artist_ids_to_follow) { service.send(:fetch_artist_ids_to_follow, new_artists_to_follow) }
 
+      context "when there are new artists to follow" do
+        let!(:artist1) { create(:artist, name: "Artist 1") }
+        let!(:artist2) { create(:artist, name: "Artist 2") }
+        let!(:artist3) { create(:artist, name: "Artist 3") }
+
+        let(:new_artists_to_follow) { [artist1, artist2] }
+
+        it "returns an array of artist IDs" do
+          expect(fetch_artist_ids_to_follow).to contain_exactly(artist1.id, artist2.id)
+        end
+      end
+
+      context "when there are no new artists to follow" do
+        let!(:existing_artists) { create_list(:artist, 3) }
+        let(:new_artists_to_follow) { [] }
+
+        it "returns an empty array" do
+          expect(fetch_artist_ids_to_follow).to be_empty
+        end
+      end
     end
 
     # TODO: Write specs

--- a/spec/services/followed_artists_service_spec.rb
+++ b/spec/services/followed_artists_service_spec.rb
@@ -13,8 +13,41 @@ RSpec.describe FollowedArtistsService do
   end
 
   describe "public methods" do
-    # TODO: Write specs
-    describe "#fetch_and_load_artists"
+    describe "#fetch_and_load_artists" do
+      let(:fetched_artists) { [
+        double("artist", name: "Artist 1", uri: "spotify:artist:1"),
+        double("artist", name: "Artist 2", uri: "spotify:artist:1"),
+      ] }
+
+      subject(:fetch_and_load_artists) { service.fetch_and_load_artists }
+
+      before do
+        allow_any_instance_of(SpotifyService).to receive(:fetch_all_followed_artists).and_return(fetched_artists)
+        allow_any_instance_of(FollowedArtistsService).to receive(:create_new_artists).with(fetched_artists)
+        allow_any_instance_of(FollowedArtistsService).to receive(:follow_new_artists).with(fetched_artists)
+        allow_any_instance_of(FollowedArtistsService).to receive(:remove_unfollowed_artists).with(fetched_artists)
+      end
+
+      it "fetches all followed artists" do
+        expect_any_instance_of(SpotifyService).to receive(:fetch_all_followed_artists)
+        fetch_and_load_artists
+      end
+
+      it "creates new artists" do
+        expect(service).to receive(:create_new_artists).with(fetched_artists)
+        fetch_and_load_artists
+      end
+
+      it "follows new artists" do
+        expect(service).to receive(:follow_new_artists).with(fetched_artists)
+        fetch_and_load_artists
+      end
+
+      it "removes unfollowed artists" do
+        expect(service).to receive(:remove_unfollowed_artists).with(fetched_artists)
+        fetch_and_load_artists
+      end
+    end
   end
 
   describe "private methods" do

--- a/spec/services/followed_artists_service_spec.rb
+++ b/spec/services/followed_artists_service_spec.rb
@@ -4,23 +4,22 @@ RSpec.describe FollowedArtistsService do
   let(:current_user) { create(:user, :with_spotify_data) }
   let(:spotify_user) { current_user.spotify_user }
 
-  subject(:spotify_service) { described_class.new(current_user) }
+  subject(:service) { described_class.new(current_user) }
 
   context "#new" do
     it "initializes current_user" do
-      expect(spotify_service.current_user).to eq(current_user)
+      expect(service.current_user).to eq(current_user)
     end
   end
 
   describe "public methods" do
-    describe "#fetch_and_load_artists" do
-
-    end
+    # TODO: Write specs
+    describe "#fetch_and_load_artists"
   end
 
   describe "private methods" do
     describe "#artists_to_create_in_db" do
-      subject(:artists_to_create) { spotify_service.send(:new_artists_to_create, fetched_artists) }
+      subject(:artists_to_create) { service.send(:new_artists_to_create, fetched_artists) }
 
       context "when there are artists to create" do
         let!(:existing_artist) { create(:artist, name: "Existing Artist 1")}
@@ -42,7 +41,7 @@ RSpec.describe FollowedArtistsService do
     end
 
     describe "#artists_to_follow" do
-      subject(:artists_to_follow) { spotify_service.send(:artists_to_follow, fetched_artists) }
+      subject(:artists_to_follow) { service.send(:artists_to_follow, fetched_artists) }
 
       context "when there are artists to follow" do
         let!(:followed_artist) { create(:artist, name: "Followed Artist 1") }
@@ -63,6 +62,35 @@ RSpec.describe FollowedArtistsService do
 
         it "returns an empty array" do
           expect(artists_to_follow).to be_empty
+        end
+      end
+    end
+
+    describe "#remove_unfollowed_artists" do
+      let!(:current_user) { create(:user, :with_spotify_data, :with_followed_artists, followed_artist_count: 2) }
+
+      subject(:remove_unfollowed_artists) { service.send(:remove_unfollowed_artists, fetched_artists) }
+
+      context "when some artists were unfollowed" do
+        let(:fetched_artists) { [double("artist", name: current_user.artists.first.name)] }
+
+        it "unfollows them" do
+          remove_unfollowed_artists
+          expect(current_user.artists).to match_array(current_user.artists.first)
+        end
+      end
+
+      context "when no artists were unfollowed" do
+        let(:existing_artists_names) { current_user.artists.pluck(:name) }
+        let(:fetched_artists) { [
+          double("artist", name: current_user.artists.first&.name),
+          double("artist", name: current_user.artists.last&.name),
+          double("artist", name: "New Followed Artist"),
+        ] }
+
+        it "doesn't unfollow them" do
+          remove_unfollowed_artists
+          expect(current_user.artists.where(name: existing_artists_names).count).to eq(2)
         end
       end
     end

--- a/spec/services/followed_artists_service_spec.rb
+++ b/spec/services/followed_artists_service_spec.rb
@@ -158,9 +158,28 @@ RSpec.describe FollowedArtistsService do
       end
     end
 
-    # TODO: Write specs
     describe "#attach_new_followed_artists" do
+      subject(:attach_new_followed_artists) { service.send(:attach_new_followed_artists, artist_ids_to_follow) }
 
+      context "when there are new artists to follow" do
+        let!(:artist1) { create(:artist) }
+        let!(:artist2) { create(:artist) }
+        let!(:artist3) { create(:artist) }
+
+        let(:artist_ids_to_follow) { [artist1.id, artist2.id] }
+
+        it "associates the new artists with the current user" do
+          expect { attach_new_followed_artists }.to change(current_user.followed_artists, :count).by(2)
+        end
+      end
+
+      context "when there are no new artists to follow" do
+        let(:artist_ids_to_follow) { [] }
+
+        it "does not associate any new artists with the current user" do
+          expect { attach_new_followed_artists }.not_to change(current_user.followed_artists, :count)
+        end
+      end
     end
 
     describe "#remove_unfollowed_artists" do

--- a/spec/services/followed_artists_service_spec.rb
+++ b/spec/services/followed_artists_service_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe FollowedArtistsService do
+  let(:current_user) { create(:user, :with_spotify_data) }
+  let(:spotify_user) { current_user.spotify_user }
+
+  subject(:spotify_service) { described_class.new(current_user) }
+
+  context "#new" do
+    it "initializes current_user" do
+      expect(spotify_service.current_user).to eq(current_user)
+    end
+  end
+
+  describe "public methods" do
+    describe "#fetch_and_load_artists" do
+
+    end
+  end
+
+  describe "private methods" do
+    describe "#artists_to_create_in_db" do
+      subject(:artists_to_create) { spotify_service.send(:new_artists_to_create, fetched_artists) }
+
+      context "when there are artists to create" do
+        let!(:existing_artist) { create(:artist, name: "Existing Artist 1")}
+        let(:fetched_artists) { [build(:artist, name: "Existing Artist 1"), build(:artist, name: "Existing Artist 2")] }
+
+        it "returns only artists not already in the database" do
+          expect(artists_to_create).to match_array(fetched_artists.last)
+        end
+      end
+
+      context "when all fetched artists already exists in the database" do
+        let!(:existing_artists) { [create(:artist, name: "Existing Artist 1"), create(:artist, name: "Existing Artist 2")]}
+        let(:fetched_artists) { [build(:artist, name: "Existing Artist 1"), build(:artist, name: "Existing Artist 2")] }
+
+        it  "returns an empty array" do
+          expect(artists_to_create).to be_empty
+        end
+      end
+    end
+
+    describe "#artists_to_follow" do
+      subject(:artists_to_follow) { spotify_service.send(:artists_to_follow, fetched_artists) }
+
+      context "when there are artists to follow" do
+        let!(:followed_artist) { create(:artist, name: "Followed Artist 1") }
+        let(:fetched_artists) { [build(:artist, name: "Followed Artist 1"), build(:artist, name: "Followed Artist 2")] }
+
+        before { current_user.artists << followed_artist }
+
+        it "follows only artists not already followed by the current user" do
+          expect(artists_to_follow).to match_array(fetched_artists.last)
+        end
+      end
+
+      context "when all fetched artists are already followed by the current user" do
+        let!(:followed_artists) { [create(:artist, name: "Followed Artist 1"), create(:artist, name: "Followed Artist 2")] }
+        let(:fetched_artists) { [build(:artist, name: "Followed Artist 1"), build(:artist, name: "Followed Artist 2")] }
+
+        before { current_user.artists << followed_artists }
+
+        it "returns an empty array" do
+          expect(artists_to_follow).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/services/followed_artists_service_spec.rb
+++ b/spec/services/followed_artists_service_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe FollowedArtistsService do
   end
 
   describe "private methods" do
-    describe "#artists_to_create_in_db" do
+    describe "#new_artists_to_create" do
       subject(:artists_to_create) { service.send(:new_artists_to_create, fetched_artists) }
 
       context "when there are artists to create" do
@@ -71,6 +71,11 @@ RSpec.describe FollowedArtistsService do
           expect(artists_to_create).to be_empty
         end
       end
+    end
+
+    # TODO: Write specs
+    describe "#create_artist_in_db" do
+
     end
 
     describe "#artists_to_follow" do
@@ -99,13 +104,23 @@ RSpec.describe FollowedArtistsService do
       end
     end
 
+    # TODO: Write specs
+    describe "#fetch_artist_ids_to_follow" do
+
+    end
+
+    # TODO: Write specs
+    describe "#attach_new_followed_artists" do
+
+    end
+
     describe "#remove_unfollowed_artists" do
       let!(:current_user) { create(:user, :with_spotify_data, :with_followed_artists, followed_artist_count: 2) }
 
       subject(:remove_unfollowed_artists) { service.send(:remove_unfollowed_artists, fetched_artists) }
 
       context "when some artists were unfollowed" do
-        let(:fetched_artists) { [double("artist", name: current_user.artists.first.name)] }
+        let(:fetched_artists) { [double("artist", name: current_user.artists.first&.name)] }
 
         it "unfollows them" do
           remove_unfollowed_artists

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SpotifyService do
       let(:artists_per_batch) { 10 }
 
       before do
-        allow(spotify_service).to receive(:fetch_batch_of_artists) do |last_artist_id|
+        allow(spotify_service).to receive(:fetch_batch_of_followed_artists) do |last_artist_id|
           # Create a batch of fake artists for the test
           if last_artist_id.nil?
             (1..artists_per_batch).map { |i| Artist.new(id: i, name: "Artist #{i}") }
@@ -56,7 +56,7 @@ RSpec.describe SpotifyService do
       end
 
       it "fetch all followed artists from Spotify" do
-        fetched_artists = spotify_service.send(:fetch_artists)
+        fetched_artists = spotify_service.send(:fetch_all_followed_artists)
 
         expect(fetched_artists.size).to eq(total_followed_artists)
       end
@@ -64,11 +64,11 @@ RSpec.describe SpotifyService do
   end
 
   describe "private methods" do
-    describe '#fetch_batch_of_artists' do
+    describe '#fetch_batch_of_followed_artists' do
       let(:last_artist_id) { '123456' }
       let(:args) { { type: 'artist', limit: described_class::SPOTIFY_MAX_LIMIT_PER_PAGE, after: last_artist_id } }
 
-      subject(:fetch_batch_of_artists) { spotify_service.send(:fetch_batch_of_artists, last_artist_id) }
+      subject(:fetch_batch_of_followed_artists) { spotify_service.send(:fetch_batch_of_followed_artists, last_artist_id) }
 
       context 'when the Spotify API call is successful' do
         let(:artists) { [double('Artist')] }
@@ -76,7 +76,7 @@ RSpec.describe SpotifyService do
         before { allow(current_user).to receive_message_chain(:spotify_user, :following).with(args).and_return(artists) }
 
         it 'returns an array of artists' do
-          expect(fetch_batch_of_artists).to eq(artists)
+          expect(fetch_batch_of_followed_artists).to eq(artists)
         end
       end
 
@@ -87,12 +87,12 @@ RSpec.describe SpotifyService do
         before { allow(current_user).to receive_message_chain(:spotify_user, :following).with(args).and_raise(error) }
 
         it 'returns nil' do
-          expect(fetch_batch_of_artists).to be_nil
+          expect(fetch_batch_of_followed_artists).to be_nil
         end
 
         it 'logs an error' do
           expect(Rails.logger).to receive(:error).with(/Error fetching batch of artists from Spotify:/)
-          fetch_batch_of_artists
+          fetch_batch_of_followed_artists
         end
       end
     end

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -4,15 +4,9 @@ RSpec.describe SpotifyService do
   let(:current_user) { create(:user, :with_spotify_data) }
   let(:spotify_user) { current_user.spotify_user }
 
-  subject(:spotify_service) { described_class.new(spotify_user) }
+  subject(:service) { described_class.new(spotify_user) }
 
   describe "public methods" do
-    describe "#new" do
-      it "initializes spotify_user" do
-        expect(spotify_service.spotify_user).to eq(spotify_user)
-      end
-    end
-
     describe "#total_followed_artists" do
       let(:spotify_user) { instance_double(RSpotify::User) }
 
@@ -24,7 +18,7 @@ RSpec.describe SpotifyService do
         before { allow(spotify_user).to receive(:following).with(type: 'artist').and_return(response_body) }
 
         it 'returns the total number of followed artists' do
-          expect(spotify_service.total_followed_artists).to eq(10)
+          expect(service.total_followed_artists).to eq(10)
         end
       end
 
@@ -33,7 +27,7 @@ RSpec.describe SpotifyService do
 
         it 'logs an error message and returns nil' do
           expect(Rails.logger).to receive(:error).with(/Unexpected error when fetching total followed artists from Spotify/)
-          expect(spotify_service.total_followed_artists).to be_nil
+          expect(service.total_followed_artists).to be_nil
         end
       end
     end
@@ -46,36 +40,55 @@ RSpec.describe SpotifyService do
       let(:fetched_artists_batch2) { [artist3] }
       let(:fetched_artists_batch3) { [] }
 
+      subject(:fetch_all_followed_artists) { service.send(:fetch_all_followed_artists) }
+
       before do
-        allow(spotify_service).to receive(:total_followed_artists).and_return(3)
-        allow(spotify_service).to receive(:fetch_batch_of_followed_artists).with(nil).and_return(fetched_artists_batch1)
-        allow(spotify_service).to receive(:fetch_batch_of_followed_artists).with('456').and_return(fetched_artists_batch2)
-        allow(spotify_service).to receive(:fetch_batch_of_followed_artists).with('789').and_return(fetched_artists_batch3)
+        allow(service).to receive(:total_followed_artists).and_return(3)
+        allow(service).to receive(:fetch_batch_of_followed_artists).with(nil).and_return(fetched_artists_batch1)
+        allow(service).to receive(:fetch_batch_of_followed_artists).with('456').and_return(fetched_artists_batch2)
+        allow(service).to receive(:fetch_batch_of_followed_artists).with('789').and_return(fetched_artists_batch3)
       end
 
       it 'fetches all followed artists from Spotify' do
-        expect(spotify_service.fetch_all_followed_artists).to eq([artist1, artist2, artist3])
+        expect(fetch_all_followed_artists).to eq([artist1, artist2, artist3])
       end
 
       it 'calls fetch_batch_of_followed_artists with correct arguments' do
-        expect(spotify_service).to receive(:fetch_batch_of_followed_artists).with(nil)
-        expect(spotify_service).to receive(:fetch_batch_of_followed_artists).with('456')
-        expect(spotify_service).not_to receive(:fetch_batch_of_followed_artists).with('789')
-        spotify_service.fetch_all_followed_artists
+        expect(service).to receive(:fetch_batch_of_followed_artists).with(nil)
+        expect(service).to receive(:fetch_batch_of_followed_artists).with('456')
+        expect(service).not_to receive(:fetch_batch_of_followed_artists).with('789')
+        fetch_all_followed_artists
       end
 
       it 'stops fetching if total number of fetched artists reaches or exceeds total number of followed artists' do
-        allow(spotify_service).to receive(:total_followed_artists).and_return(1)
-        expect(spotify_service).to receive(:fetch_batch_of_followed_artists).with(nil).and_return(fetched_artists_batch1)
-        expect(spotify_service).not_to receive(:fetch_batch_of_followed_artists).with('456')
-        expect(spotify_service).not_to receive(:fetch_batch_of_followed_artists).with('789')
-        spotify_service.fetch_all_followed_artists
+        allow(service).to receive(:total_followed_artists).and_return(1)
+        expect(service).to receive(:fetch_batch_of_followed_artists).with(nil).and_return(fetched_artists_batch1)
+        expect(service).not_to receive(:fetch_batch_of_followed_artists).with('456')
+        expect(service).not_to receive(:fetch_batch_of_followed_artists).with('789')
+        fetch_all_followed_artists
       end
 
       it 'stops fetching if maximum loop count is exceeded' do
         stub_const("SpotifyService::MAX_LOOP", -1)
-        expect(spotify_service).to receive(:fetch_batch_of_followed_artists).once
-        spotify_service.fetch_all_followed_artists
+        expect(service).to receive(:fetch_batch_of_followed_artists).once
+        fetch_all_followed_artists
+      end
+    end
+
+    describe "#artists" do
+      context "when there are some fetched_artists" do
+        let(:artist1) { double('RSpotify::Artist', name: "Artist 1", uri: "spotify:artist1", images: [{ "url" => "https://artist1.jpg" }]) }
+        let(:artist2) { double('RSpotify::Artist', name: "Artist 2", uri: "spotify:artist2", images: [{ "url" => "https://artist2.jpg" }]) }
+        let(:fetched_artists) { [artist1, artist2] }
+
+        before { allow(service).to receive(:fetch_all_followed_artists).and_return(fetched_artists) }
+
+        it "returns an array of Artist objects" do
+          expect(service.artists.first).to be_an(Artist)
+          expect(service.artists.first).to have_attributes(name: "Artist 1", external_link: "spotify:artist1", cover_url: "https://artist1.jpg")
+          expect(service.artists.last).to be_an(Artist)
+          expect(service.artists.last).to have_attributes(name: "Artist 2", external_link: "spotify:artist2", cover_url: "https://artist2.jpg")
+        end
       end
     end
   end
@@ -85,7 +98,7 @@ RSpec.describe SpotifyService do
       let(:last_artist_id) { '123456' }
       let(:args) { { type: 'artist', limit: described_class::SPOTIFY_MAX_LIMIT_PER_PAGE, after: last_artist_id } }
 
-      subject(:fetch_batch_of_followed_artists) { spotify_service.send(:fetch_batch_of_followed_artists, last_artist_id) }
+      subject(:fetch_batch_of_followed_artists) { service.send(:fetch_batch_of_followed_artists, last_artist_id) }
 
       context 'when the Spotify API call is successful' do
         let(:artists) { [double('Artist')] }

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -3,186 +3,97 @@ require "rails_helper"
 RSpec.describe SpotifyService do
   let(:current_user) { create(:user, :with_spotify_data) }
   let(:spotify_user) { current_user.spotify_user }
-  let(:following_mock) {
-    [
-      RSpotify::Artist.new(
-          followers: {
-            href: nil,
-            total: 115414
-          },
-          genres: [
-            "french pop",
-            "nouvelle chanson francaise"
-          ],
-          images: [
-            {
-              height: 640,
-              url: "https://i.scdn.co/image/ab6761610000e5eb0c9b46616573eacd85a357bd",
-              width: 640
-            },
-            {
-              height: 320,
-              url: "https://i.scdn.co/image/ab676161000051740c9b46616573eacd85a357bd",
-              width: 320
-            },
-            {
-              height: 160,
-              url: "https://i.scdn.co/image/ab6761610000f1780c9b46616573eacd85a357bd",
-              width: 160
-            }
-          ],
-          name: "Suzane",
-          popularity: 44,
-          top_tracks: {},
-          external_urls: {
-            spotify: "https://open.spotify.com/artist/00CTomLgA78xvwEwL0woWx"
-          },
-          href: "https://api.spotify.com/v1/artists/00CTomLgA78xvwEwL0woWx",
-          id: "00CTomLgA78xvwEwL0woWx",
-          type: "artist",
-          uri: "spotify:artist:00CTomLgA78xvwEwL0woWx"
-      )
-    ]
-  }
 
-  subject(:spotify_service) { described_class.new(current_user) }
+  subject(:spotify_service) { described_class.new(spotify_user) }
 
-  context "#new" do
-    it "initializes current_user" do
-      expect(spotify_service.current_user).to eq(current_user)
-    end
-  end
-
-  describe "#fetch_and_load_artists" do
-
-  end
-
-  describe "#total_followed_artists" do
-    let(:spotify_user) { instance_double(RSpotify::User) }
-
-    before { allow(current_user).to receive(:spotify_user).and_return(spotify_user) }
-
-    context 'when the Spotify API returns a valid response' do
-      let(:response_body) { { "artists" => { "total" => 10 } }.to_json }
-
-      before { allow(spotify_user).to receive(:following).with(type: 'artist').and_return(response_body) }
-
-      it 'returns the total number of followed artists' do
-        expect(spotify_service.total_followed_artists).to eq(10)
+  describe "public methods" do
+    describe "#new" do
+      it "initializes spotify_user" do
+        expect(spotify_service.spotify_user).to eq(spotify_user)
       end
     end
 
-    context 'when the Spotify API returns an error response' do
-      before { allow(spotify_user).to receive(:following).with(type: 'artist').and_raise(RestClient::ExceptionWithResponse) }
+    describe "#total_followed_artists" do
+      let(:spotify_user) { instance_double(RSpotify::User) }
 
-      it 'logs an error message and returns nil' do
-        expect(Rails.logger).to receive(:error).with(/Unexpected error when fetching total followed artists from Spotify/)
-        expect(spotify_service.total_followed_artists).to be_nil
-      end
-    end
-  end
+      before { allow(current_user).to receive(:spotify_user).and_return(spotify_user) }
 
-  describe '#fetch_batch_of_artists' do
-    let(:last_artist_id) { '123456' }
-    let(:args) { { type: 'artist', limit: described_class::SPOTIFY_MAX_LIMIT_PER_PAGE, after: last_artist_id } }
+      context 'when the Spotify API returns a valid response' do
+        let(:response_body) { { "artists" => { "total" => 10 } }.to_json }
 
-    subject(:fetch_batch_of_artists) { spotify_service.send(:fetch_batch_of_artists, last_artist_id) }
+        before { allow(spotify_user).to receive(:following).with(type: 'artist').and_return(response_body) }
 
-    context 'when the Spotify API call is successful' do
-      let(:artists) { [double('Artist')] }
-
-      before { allow(current_user).to receive_message_chain(:spotify_user, :following).with(args).and_return(artists) }
-
-      it 'returns an array of artists' do
-        expect(fetch_batch_of_artists).to eq(artists)
-      end
-    end
-
-    context 'when the Spotify API call fails' do
-      let(:last_artist_id) { '123456' }
-      let(:error) { RestClient::ExceptionWithResponse.new('Unauthorized', 401) }
-
-      before { allow(current_user).to receive_message_chain(:spotify_user, :following).with(args).and_raise(error) }
-
-      it 'returns nil' do
-        expect(fetch_batch_of_artists).to be_nil
+        it 'returns the total number of followed artists' do
+          expect(spotify_service.total_followed_artists).to eq(10)
+        end
       end
 
-      it 'logs an error' do
-        expect(Rails.logger).to receive(:error).with(/Error fetching batch of artists from Spotify:/)
-        fetch_batch_of_artists
-      end
-    end
-  end
+      context 'when the Spotify API returns an error response' do
+        before { allow(spotify_user).to receive(:following).with(type: 'artist').and_raise(RestClient::ExceptionWithResponse) }
 
-  describe "#fetch_artists" do
-    let(:total_followed_artists) { 50 }
-    let(:artists_per_batch) { 10 }
-
-    before do
-      allow(spotify_service).to receive(:fetch_batch_of_artists) do |last_artist_id|
-        # Create a batch of fake artists for the test
-        if last_artist_id.nil?
-          (1..artists_per_batch).map { |i| Artist.new(id: i, name: "Artist #{i}") }
-        else
-          last_id = last_artist_id.to_i
-          next_id = last_id + artists_per_batch
-          (last_id + 1..next_id).map { |i| Artist.new(id: i, name: "Artist #{i}") }
+        it 'logs an error message and returns nil' do
+          expect(Rails.logger).to receive(:error).with(/Unexpected error when fetching total followed artists from Spotify/)
+          expect(spotify_service.total_followed_artists).to be_nil
         end
       end
     end
 
-    it "fetch all followed artists from Spotify" do
-      fetched_artists = spotify_service.send(:fetch_artists)
+    describe "#fetch_artists" do
+      let(:total_followed_artists) { 50 }
+      let(:artists_per_batch) { 10 }
 
-      expect(fetched_artists.size).to eq(total_followed_artists)
-    end
-  end
-
-  describe "#artists_to_create_in_db" do
-    subject(:artists_to_create) { spotify_service.send(:new_artists_to_create, fetched_artists) }
-
-    context "when there are artists to create" do
-      let!(:existing_artist) { create(:artist, name: "Existing Artist 1")}
-      let(:fetched_artists) { [build(:artist, name: "Existing Artist 1"), build(:artist, name: "Existing Artist 2")] }
-
-      it "returns only artists not already in the database" do
-        expect(artists_to_create).to match_array(fetched_artists.last)
+      before do
+        allow(spotify_service).to receive(:fetch_batch_of_artists) do |last_artist_id|
+          # Create a batch of fake artists for the test
+          if last_artist_id.nil?
+            (1..artists_per_batch).map { |i| Artist.new(id: i, name: "Artist #{i}") }
+          else
+            last_id = last_artist_id.to_i
+            next_id = last_id + artists_per_batch
+            (last_id + 1..next_id).map { |i| Artist.new(id: i, name: "Artist #{i}") }
+          end
+        end
       end
-    end
 
-    context "when all fetched artists already exists in the database" do
-      let!(:existing_artists) { [create(:artist, name: "Existing Artist 1"), create(:artist, name: "Existing Artist 2")]}
-      let(:fetched_artists) { [build(:artist, name: "Existing Artist 1"), build(:artist, name: "Existing Artist 2")] }
+      it "fetch all followed artists from Spotify" do
+        fetched_artists = spotify_service.send(:fetch_artists)
 
-      it  "returns an empty array" do
-        expect(artists_to_create).to be_empty
+        expect(fetched_artists.size).to eq(total_followed_artists)
       end
     end
   end
 
-  describe "#artists_to_follow" do
-    subject(:artists_to_follow) { spotify_service.send(:artists_to_follow, fetched_artists) }
+  describe "private methods" do
+    describe '#fetch_batch_of_artists' do
+      let(:last_artist_id) { '123456' }
+      let(:args) { { type: 'artist', limit: described_class::SPOTIFY_MAX_LIMIT_PER_PAGE, after: last_artist_id } }
 
-    context "when there are artists to follow" do
-      let!(:followed_artist) { create(:artist, name: "Followed Artist 1") }
-      let(:fetched_artists) { [build(:artist, name: "Followed Artist 1"), build(:artist, name: "Followed Artist 2")] }
+      subject(:fetch_batch_of_artists) { spotify_service.send(:fetch_batch_of_artists, last_artist_id) }
 
-      before { current_user.artists << followed_artist }
+      context 'when the Spotify API call is successful' do
+        let(:artists) { [double('Artist')] }
 
-      it "follows only artists not already followed by the current user" do
-        expect(artists_to_follow).to match_array(fetched_artists.last)
+        before { allow(current_user).to receive_message_chain(:spotify_user, :following).with(args).and_return(artists) }
+
+        it 'returns an array of artists' do
+          expect(fetch_batch_of_artists).to eq(artists)
+        end
       end
-    end
 
-    context "when all fetched artists are already followed by the current user" do
-      let!(:followed_artists) { [create(:artist, name: "Followed Artist 1"), create(:artist, name: "Followed Artist 2")] }
-      let(:fetched_artists) { [build(:artist, name: "Followed Artist 1"), build(:artist, name: "Followed Artist 2")] }
+      context 'when the Spotify API call fails' do
+        let(:last_artist_id) { '123456' }
+        let(:error) { RestClient::ExceptionWithResponse.new('Unauthorized', 401) }
 
-      before { current_user.artists << followed_artists }
+        before { allow(current_user).to receive_message_chain(:spotify_user, :following).with(args).and_raise(error) }
 
-      it "returns an empty array" do
-        expect(artists_to_follow).to be_empty
+        it 'returns nil' do
+          expect(fetch_batch_of_artists).to be_nil
+        end
+
+        it 'logs an error' do
+          expect(Rails.logger).to receive(:error).with(/Error fetching batch of artists from Spotify:/)
+          fetch_batch_of_artists
+        end
       end
     end
   end

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe SpotifyService do
         allow(service).to receive(:fetch_batch_of_followed_artists).with(nil).and_return(fetched_artists_batch1)
         allow(service).to receive(:fetch_batch_of_followed_artists).with('456').and_return(fetched_artists_batch2)
         allow(service).to receive(:fetch_batch_of_followed_artists).with('789').and_return(fetched_artists_batch3)
+        stub_const("SpotifyService::SPOTIFY_MAX_LIMIT_PER_PAGE", 2)
       end
 
       it 'fetches all followed artists from Spotify' do
@@ -70,8 +71,7 @@ RSpec.describe SpotifyService do
       end
 
       it 'stops fetching if maximum loop count is exceeded' do
-        stub_const("SpotifyService::MAX_LOOP", -1)
-        expect(service).to receive(:fetch_batch_of_followed_artists).once
+        expect(service).to receive(:fetch_batch_of_followed_artists).twice
         fetch_all_followed_artists
       end
     end

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe SpotifyService do
 
   describe "public methods" do
     describe "#total_followed_artists" do
-      let(:spotify_user) { instance_double(RSpotify::User) }
-
       before { allow(current_user).to receive(:spotify_user).and_return(spotify_user) }
 
       context 'when the Spotify API returns a valid response' do
@@ -23,10 +21,13 @@ RSpec.describe SpotifyService do
       end
 
       context 'when the Spotify API returns an error response' do
-        before { allow(spotify_user).to receive(:following).with(type: 'artist').and_raise(RestClient::ExceptionWithResponse) }
+        before do
+          allow(spotify_user).to receive(:following).with(type: 'artist').and_raise(RestClient::ExceptionWithResponse)
+        end
 
         it 'logs an error message and returns nil' do
-          expect(Rails.logger).to receive(:error).with(/Unexpected error when fetching total followed artists from Spotify/)
+          error_message = /Unexpected error when fetching total followed artists from Spotify/
+          expect(Rails.logger).to receive(:error).with(error_message)
           expect(service.total_followed_artists).to be_nil
         end
       end

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SpotifyService do
     ]
   }
 
-  subject(:spotify_service) { SpotifyService.new(current_user) }
+  subject(:spotify_service) { described_class.new(current_user) }
 
   context "#new" do
     it "initializes current_user" do
@@ -53,24 +53,137 @@ RSpec.describe SpotifyService do
     end
   end
 
-  context "#load_artists" do
-    subject(:fetch_and_load_artists) { spotify_service.fetch_and_load_artists }
+  describe "#fetch_and_load_artists" do
 
-    context "when there is a new followed artist" do
-      before do
-        allow_any_instance_of(RSpotify::User).to receive(:following).and_return(following_mock)
+  end
+
+  describe "#total_followed_artists" do
+    let(:spotify_user) { instance_double(RSpotify::User) }
+
+    before { allow(current_user).to receive(:spotify_user).and_return(spotify_user) }
+
+    context 'when the Spotify API returns a valid response' do
+      let(:response_body) { { "artists" => { "total" => 10 } }.to_json }
+
+      before { allow(spotify_user).to receive(:following).with(type: 'artist').and_return(response_body) }
+
+      it 'returns the total number of followed artists' do
+        expect(spotify_service.total_followed_artists).to eq(10)
       end
-
-      it "adds a new artist into the database" do
-      #   expect(fetch_and_load_followed_artists).to change(Artist, :count).by(1)
-      end
-
-      # it "adds the artist to the user's followed artists"
     end
 
-    context "when a spotify artist has been unfollowed" do
-      it "removes the link from the user's followed artists"
-      it "keeps the artist into the database"
+    context 'when the Spotify API returns an error response' do
+      before { allow(spotify_user).to receive(:following).with(type: 'artist').and_raise(RestClient::ExceptionWithResponse) }
+
+      it 'logs an error message and returns nil' do
+        expect(Rails.logger).to receive(:error).with(/Unexpected error when fetching total followed artists from Spotify/)
+        expect(spotify_service.total_followed_artists).to be_nil
+      end
+    end
+  end
+
+  describe '#fetch_batch_of_artists' do
+    let(:last_artist_id) { '123456' }
+    let(:args) { { type: 'artist', limit: described_class::SPOTIFY_MAX_LIMIT_PER_PAGE, after: last_artist_id } }
+
+    subject(:fetch_batch_of_artists) { spotify_service.send(:fetch_batch_of_artists, last_artist_id) }
+
+    context 'when the Spotify API call is successful' do
+      let(:artists) { [double('Artist')] }
+
+      before { allow(current_user).to receive_message_chain(:spotify_user, :following).with(args).and_return(artists) }
+
+      it 'returns an array of artists' do
+        expect(fetch_batch_of_artists).to eq(artists)
+      end
+    end
+
+    context 'when the Spotify API call fails' do
+      let(:last_artist_id) { '123456' }
+      let(:error) { RestClient::ExceptionWithResponse.new('Unauthorized', 401) }
+
+      before { allow(current_user).to receive_message_chain(:spotify_user, :following).with(args).and_raise(error) }
+
+      it 'returns nil' do
+        expect(fetch_batch_of_artists).to be_nil
+      end
+
+      it 'logs an error' do
+        expect(Rails.logger).to receive(:error).with(/Error fetching batch of artists from Spotify:/)
+        fetch_batch_of_artists
+      end
+    end
+  end
+
+  describe "#fetch_artists" do
+    let(:total_followed_artists) { 50 }
+    let(:artists_per_batch) { 10 }
+
+    before do
+      allow(spotify_service).to receive(:fetch_batch_of_artists) do |last_artist_id|
+        # Create a batch of fake artists for the test
+        if last_artist_id.nil?
+          (1..artists_per_batch).map { |i| Artist.new(id: i, name: "Artist #{i}") }
+        else
+          last_id = last_artist_id.to_i
+          next_id = last_id + artists_per_batch
+          (last_id + 1..next_id).map { |i| Artist.new(id: i, name: "Artist #{i}") }
+        end
+      end
+    end
+
+    it "fetch all followed artists from Spotify" do
+      fetched_artists = spotify_service.send(:fetch_artists)
+
+      expect(fetched_artists.size).to eq(total_followed_artists)
+    end
+  end
+
+  describe "#artists_to_create_in_db" do
+    subject(:artists_to_create) { spotify_service.send(:artists_to_create_in_db, fetched_artists) }
+
+    context "when there are artists to create" do
+      let!(:existing_artist) { create(:artist, name: "Existing Artist 1")}
+      let(:fetched_artists) { [build(:artist, name: "Existing Artist 1"), build(:artist, name: "Existing Artist 2")] }
+
+      it "returns only artists not already in the database" do
+        expect(artists_to_create).to match_array(fetched_artists.last)
+      end
+    end
+
+    context "when all fetched artists already exists in the database" do
+      let!(:existing_artists) { [create(:artist, name: "Existing Artist 1"), create(:artist, name: "Existing Artist 2")]}
+      let(:fetched_artists) { [build(:artist, name: "Existing Artist 1"), build(:artist, name: "Existing Artist 2")] }
+
+      it  "returns an empty array" do
+        expect(artists_to_create).to be_empty
+      end
+    end
+  end
+
+  describe "#artists_to_follow" do
+    subject(:artists_to_follow) { spotify_service.send(:artists_to_follow, fetched_artists) }
+
+    context "when there are artists to follow" do
+      let!(:followed_artist) { create(:artist, name: "Followed Artist 1") }
+      let(:fetched_artists) { [build(:artist, name: "Followed Artist 1"), build(:artist, name: "Followed Artist 2")] }
+
+      before { current_user.artists << followed_artist }
+
+      it "follows only artists not already followed by the current user" do
+        expect(artists_to_follow).to match_array(fetched_artists.last)
+      end
+    end
+
+    context "when all fetched artists are already followed by the current user" do
+      let!(:followed_artists) { [create(:artist, name: "Followed Artist 1"), create(:artist, name: "Followed Artist 2")] }
+      let(:fetched_artists) { [build(:artist, name: "Followed Artist 1"), build(:artist, name: "Followed Artist 2")] }
+
+      before { current_user.artists << followed_artists }
+
+      it "returns an empty array" do
+        expect(artists_to_follow).to be_empty
+      end
     end
   end
 end

--- a/spec/services/spotify_service_spec.rb
+++ b/spec/services/spotify_service_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe SpotifyService do
   end
 
   describe "#artists_to_create_in_db" do
-    subject(:artists_to_create) { spotify_service.send(:artists_to_create_in_db, fetched_artists) }
+    subject(:artists_to_create) { spotify_service.send(:new_artists_to_create, fetched_artists) }
 
     context "when there are artists to create" do
       let!(:existing_artist) { create(:artist, name: "Existing Artist 1")}

--- a/spec/sidekiq/sync_artists_job_spec.rb
+++ b/spec/sidekiq/sync_artists_job_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe FetchArtistsJob, type: :job do
     let(:user) { create(:user) }
 
     it "calls SpotifyService to fetch the followed artists of the current user" do
-      spotify_service_double = instance_double(SpotifyService)
-      allow(SpotifyService).to receive(:new).with(user).and_return(spotify_service_double)
-      expect(spotify_service_double).to receive(:fetch_and_load_artists)
+      followed_artist_double = instance_double(FollowedArtistsService)
+      allow(FollowedArtistsService).to receive(:new).with(user).and_return(followed_artist_double)
+      expect(followed_artist_double).to receive(:fetch_and_load_artists)
 
       FetchArtistsJob.new.perform(user.id)
     end


### PR DESCRIPTION
## Description

An issue was raised [here](https://github.com/davidBentoPereira/spotify-library/pull/2#discussion_r1539004391) saying that we need better error management and more context in the `SpotifyService`.

After discussion with @Zaratan, we also decided to refactor our service for better understanding, maintenance and testability.

We want :
- [x] To use the gem https://github.com/zdennis/activerecord-import to bulk import the artists into the database
- [x] The `SpotifyService` to only handle the connection with the Spotify API
- [x] A new service called `FollowedArtistsService` handling the import of spotify's followed artists into the database
- [x] To test ALL the methods (even the private ones)

Bonus or next ticket :
- [ ] Better error handling with more context (at which step does it fails ? Why ?)
- [ ] Implement DRY Transaction or Interactor+Organizers ?
- [ ] Refactor FollowedArtistsService to be agnostic from any Streaming Music Platform (should work in the futur with Deezer or Apple Music for example)
- [ ] To improve our services to search existing followed_artists by id rather than by name, resulting in improved performances and less complicated code and queries